### PR TITLE
Added an option to use a lighter text color

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -14,6 +14,9 @@
     <entry name="animations" type="Bool">
         <default>true</default>
     </entry>
+    <entry name="lightText" type="Bool">
+        <default>false</default>
+    </entry>
     <entry name="updateInterval" type="Int">
         <default>30</default>
     </entry>

--- a/plasmoid/contents/ui/config/general.qml
+++ b/plasmoid/contents/ui/config/general.qml
@@ -10,6 +10,7 @@ Item {
   property alias cfg_dropTarget: dropTargetCheckBox.checked
   property alias cfg_logo: logoCheckBox.checked
   property alias cfg_animations: animationsCheckBox.checked
+  property alias cfg_lightText: lightTextCheckBox.checked
 
   property alias cfg_updateInterval: updateInterval.value
   property alias cfg_switchInterval: switchInterval.value
@@ -40,6 +41,12 @@ Item {
           id: animationsCheckBox
           text: i18n("Animations")
         }
+
+        QtControls.CheckBox {
+          id: lightTextCheckBox
+          text: i18n("Show light text")
+        }
+
       }
     }
 

--- a/plasmoid/contents/ui/content/DropTarget.qml
+++ b/plasmoid/contents/ui/content/DropTarget.qml
@@ -6,7 +6,8 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 
 Item{
   id: dropTarget
-
+  property alias dropTitle: title
+  property alias dropText: txt
   Rectangle{
     anchors.fill: parent
     color: theme.backgroundColor
@@ -26,6 +27,7 @@ Item{
         Layout.alignment: Qt.AlignVCenter
 
         Label{
+          id: title
           Layout.fillWidth: true
           text: "Drop a feed here..."
           wrapMode: Text.WordWrap
@@ -33,6 +35,7 @@ Item{
         }
 
         Label{
+          id: txt
           Layout.fillWidth: true
           text: "...to add one more entry!"
           wrapMode: Text.WordWrap

--- a/plasmoid/contents/ui/content/Feed.qml
+++ b/plasmoid/contents/ui/content/Feed.qml
@@ -142,6 +142,8 @@ Row {
 
   function getFontColor(){
     if (lightText){
+      dropTarget.dropTitle.color = "lightgray"
+      dropTarget.dropText.color = "lightgray"
       return "lightgray"
     } else {
       return "black"

--- a/plasmoid/contents/ui/content/Feed.qml
+++ b/plasmoid/contents/ui/content/Feed.qml
@@ -23,6 +23,7 @@ Row {
   property int delayedPrev: 0
   property int delayedNext: 0
   property int animationDuration: 500
+  property bool lightText: false
   property var hovered: false
   property var iconSource
 
@@ -139,6 +140,14 @@ Row {
     return animationDuration/(Math.max(delayedPrev+1, delayedNext+1));
   }
 
+  function getFontColor(){
+    if (lightText){
+      return "lightgray"
+    } else {
+      return "black"
+    }
+  }
+
   function createNewsIfModelLoaded(){
     if(!feedReady()){
       modelLoadTimer.running = true;
@@ -155,8 +164,10 @@ Row {
       "numberOfNews": feed.model.count,
       "currentNewsNumber": feed.currentIndex + 1,
       "iconSource": feed.iconSource,
-      "feedTitle": feed.titleModel.get(0).feedTitle
+      "feedTitle": feed.titleModel.get(0).feedTitle,
+      "feedColor": getFontColor()
     });
+
   }
 
   function feedReady(){
@@ -238,8 +249,10 @@ Row {
       "numberOfNews": feed.model.count,
       "currentNewsNumber": feed.currentIndex + 1,
       "iconSource": feed.iconSource,
-      "feedTitle": feed.titleModel.get(0).feedTitle
+      "feedTitle": feed.titleModel.get(0).feedTitle,
+      "feedColor": getFontColor()
     });
+
 
     if(hovered){
       newNews.feedTitleToFuzzyDate();

--- a/plasmoid/contents/ui/content/News.qml
+++ b/plasmoid/contents/ui/content/News.qml
@@ -16,6 +16,7 @@ Item{
   property int movementDuration
   property var iconSource
   property var feedTitle
+  property var feedColor
 
   Rectangle{
     anchors.fill: parent
@@ -37,7 +38,9 @@ Item{
 
         Label{
           text: "(" + news.currentNewsNumber + "/" + news.numberOfNews + ")"
+          color: news.feedColor
           wrapMode: Text.WordWrap
+
         }
 
         Label{
@@ -45,6 +48,7 @@ Item{
           Layout.fillWidth: true
           text: news.feedTitle
           wrapMode: Text.WordWrap
+          color: news.feedColor
           font.bold: true
         }
       }
@@ -55,6 +59,7 @@ Item{
           Layout.fillWidth: true
           text: news.currentNews.title
           wrapMode: Text.WordWrap
+          color: news.feedColor
         }
       }
     }

--- a/plasmoid/contents/ui/content/News.qml
+++ b/plasmoid/contents/ui/content/News.qml
@@ -38,7 +38,6 @@ Item{
         Label{
           text: "(" + news.currentNewsNumber + "/" + news.numberOfNews + ")"
           wrapMode: Text.WordWrap
-          font.bold: true
         }
 
         Label{

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -20,7 +20,7 @@ Item{
   property bool showDropTarget: plasmoid.configuration.dropTarget
   property bool animations: plasmoid.configuration.animations
   property bool userConfiguring: plasmoid.userConfiguring
-  property bool showLighText: plasmoid.configuration.lightText
+  property bool lightText: plasmoid.configuration.lightText
 
   onShowLogoChanged: setMinimumHeight()
   onShowDropTargetChanged: setMinimumHeight()
@@ -35,7 +35,6 @@ Item{
     if(userConfiguring){
       return;
     }
-
     var newSources = sourceList.split(',');
     if(!identicalSources(sources, newSources)){
       sources = newSources;
@@ -184,6 +183,7 @@ Item{
       Layout.fillWidth: true;\
       Layout.fillHeight: true;\
       animate: mainWindow.animations;\
+      lightText: mainWindow.lightText;\
       model: XmlListModel {\
         source: "' + source + '";\
         query: "/rss/channel/item";\

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -20,6 +20,7 @@ Item{
   property bool showDropTarget: plasmoid.configuration.dropTarget
   property bool animations: plasmoid.configuration.animations
   property bool userConfiguring: plasmoid.userConfiguring
+  property bool showLighText: plasmoid.configuration.lightText
 
   onShowLogoChanged: setMinimumHeight()
   onShowDropTargetChanged: setMinimumHeight()


### PR DESCRIPTION
The attached patch add a configuration option that should fix issue #3, adding an option to use a lighter (lightgray) color for the text when plasma is set to use a dark theme.
